### PR TITLE
feat: add PostgreSQL database URL creation and JWT key retrieval

### DIFF
--- a/database_darwin.go
+++ b/database_darwin.go
@@ -1,0 +1,59 @@
+//go:build darwin
+
+package utils
+
+import (
+	"fmt"
+	"net/url"
+	"os"
+	"text/template"
+
+	"gopkg.in/ini.v1"
+)
+
+func CreatePostgresDatabaseURL() (string, error) {
+	// First check for environment variable (useful for development)
+	if envURL := os.Getenv("OPENUEM_DATABASE_URL"); envURL != "" {
+		return envURL, nil
+	}
+
+	var err error
+
+	// Open ini file
+	cfg, err := ini.Load(GetConfigFile())
+	if err != nil {
+		return "", err
+	}
+
+	user, err := cfg.Section("DB").GetKey("PostgresUser")
+	if err != nil {
+		return "", fmt.Errorf("could not read PostgresUser from INI")
+	}
+	username := url.PathEscape(user.String())
+
+	host, err := cfg.Section("DB").GetKey("PostgresHost")
+	if err != nil {
+		return "", fmt.Errorf("could not read PostgresHost from INI")
+	}
+	hostname := url.PathEscape(host.String())
+
+	port, err := cfg.Section("DB").GetKey("PostgresPort")
+	if err != nil {
+		return "", fmt.Errorf("could not read PostgresPort from INI")
+	}
+	dbPort := url.PathEscape(port.String())
+
+	database, err := cfg.Section("DB").GetKey("PostgresDatabase")
+	if err != nil {
+		return "", fmt.Errorf("could not read PostgresDatabase from INI")
+	}
+	databaseName := url.PathEscape(database.String())
+
+	pass, err := cfg.Section("DB").GetKey("PostgresPassword")
+	if err != nil {
+		return "", fmt.Errorf("could not read PostgresPassword from INI")
+	}
+	password := template.URLQueryEscaper(pass.String())
+
+	return fmt.Sprintf("postgres://%s:%s@%s:%s/%s", username, password, hostname, dbPort, databaseName), nil
+}

--- a/jwt_darwin.go
+++ b/jwt_darwin.go
@@ -1,0 +1,31 @@
+//go:build darwin
+
+package utils
+
+import (
+	"fmt"
+	"os"
+
+	"gopkg.in/ini.v1"
+)
+
+func GetJWTKey() (string, error) {
+	// First check for environment variable (useful for development)
+	if envKey := os.Getenv("OPENUEM_JWT_KEY"); envKey != "" {
+		return envKey, nil
+	}
+
+	// Open ini file
+	configFile := GetConfigFile()
+	cfg, err := ini.Load(configFile)
+	if err != nil {
+		return "", err
+	}
+
+	key, err := cfg.Section("JWT").GetKey("Key")
+	if err != nil {
+		return "", fmt.Errorf("could not read JWT Key from INI")
+	}
+
+	return key.String(), nil
+}

--- a/logger_darwin.go
+++ b/logger_darwin.go
@@ -3,7 +3,10 @@
 package utils
 
 import (
+	"log"
 	"os"
+	"path/filepath"
+	"strings"
 )
 
 type OpenUEMLogger struct {
@@ -12,4 +15,60 @@ type OpenUEMLogger struct {
 
 func (l *OpenUEMLogger) Close() {
 	l.LogFile.Close()
+}
+
+func NewLogger(logFilename string) *OpenUEMLogger {
+	var err error
+
+	logger := OpenUEMLogger{}
+
+	// Get user home directory for logs on macOS
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		log.Fatalf("[FATAL]: could not get user home directory, reason: %v", err)
+	}
+
+	wd := filepath.Join(homeDir, ".openuem", "logs")
+
+	if _, err := os.Stat(wd); os.IsNotExist(err) {
+		if err := os.MkdirAll(wd, 0755); err != nil {
+			log.Fatalf("[FATAL]: could not create log directory, reason: %v", err)
+		}
+	}
+
+	logPath := filepath.Join(wd, logFilename)
+	logger.LogFile, err = os.Create(logPath)
+	if err != nil {
+		log.Fatalf("could not create log file: %v", err)
+	}
+
+	logPrefix := strings.TrimSuffix(filepath.Base(logFilename), filepath.Ext(logFilename))
+	log.SetOutput(logger.LogFile)
+	log.SetPrefix(logPrefix + ": ")
+	log.SetFlags(log.Ldate | log.Ltime)
+
+	return &logger
+}
+
+func NewAuthLogger() *log.Logger {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		log.Fatalf("[FATAL]: could not get user home directory, reason: %v", err)
+	}
+
+	wd := filepath.Join(homeDir, ".openuem", "logs")
+
+	if _, err := os.Stat(wd); os.IsNotExist(err) {
+		if err := os.MkdirAll(wd, 0755); err != nil {
+			log.Fatalf("[FATAL]: could not create log directory, reason: %v", err)
+		}
+	}
+
+	logPath := filepath.Join(wd, "auth.log")
+	logFile, err := os.OpenFile(logPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		log.Fatalf("could not open auth log file: %v", err)
+	}
+
+	return log.New(logFile, "auth: ", log.Ldate|log.Ltime)
 }


### PR DESCRIPTION
This pull request introduces macOS-specific implementations for database connection, JWT key retrieval, and logging functionality in the `utils` package. The changes provide Darwin (macOS) support for reading configuration values from INI files, handling environment variables, and managing log files in user directories. The most important changes are grouped below:

**Database and JWT configuration for macOS:**

* Added `CreatePostgresDatabaseURL` function in `database_darwin.go` to construct a PostgreSQL connection URL using environment variables or INI configuration, with proper escaping for all components.
* Added `GetJWTKey` function in `jwt_darwin.go` to retrieve the JWT key from an environment variable or the INI configuration file.

**Logging enhancements for macOS:**

* Added imports for `log`, `filepath`, and `strings` in `logger_darwin.go` to support new logging features.
* Introduced `NewLogger` function in `logger_darwin.go` to create log files under the user's home directory, set log prefixes, and configure log output for general logging.
* Introduced `NewAuthLogger` function in `logger_darwin.go` to create and configure a dedicated logger for authentication events, writing to `auth.log` in the user's home directory.